### PR TITLE
Fix: Simplify title extraction and consolidate logic

### DIFF
--- a/backend/internal/vault/benchmark_test.go
+++ b/backend/internal/vault/benchmark_test.go
@@ -270,7 +270,7 @@ func BenchmarkExtractTitle(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		for _, path := range paths {
-			_ = extractTitle(path)
+			_ = extractTitle(path, nil)
 		}
 	}
 }

--- a/backend/internal/vault/graph_builder.go
+++ b/backend/internal/vault/graph_builder.go
@@ -346,13 +346,7 @@ func (gb *GraphBuilder) buildEdges(
 
 // createNode creates a VaultNode from a MarkdownFile
 func (gb *GraphBuilder) createNode(file *MarkdownFile, id string) (*models.VaultNode, error) {
-	// Extract title (prefer frontmatter title, fallback to filename)
 	title := file.Title
-	if file.Frontmatter != nil {
-		if fmTitle, ok := file.Frontmatter.GetString("title"); ok && fmTitle != "" {
-			title = fmTitle
-		}
-	}
 
 	// Determine node type using classifier
 	nodeType := ""

--- a/backend/internal/vault/graph_builder_test.go
+++ b/backend/internal/vault/graph_builder_test.go
@@ -518,7 +518,7 @@ func TestCreateNode_WithMetadata(t *testing.T) {
 
 	file := &MarkdownFile{
 		Path:        "test.md",
-		Title:       "Filename Title",
+		Title:       "Custom Title", // Title already includes frontmatter override from markdown.go
 		Content:     "Test content",
 		Frontmatter: frontmatter,
 		FileInfo:    &testFileInfo{modTime: time.Now()},
@@ -528,7 +528,7 @@ func TestCreateNode_WithMetadata(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, "test", node.ID)
-	assert.Equal(t, "Custom Title", node.Title) // Prefers frontmatter title
+	assert.Equal(t, "Custom Title", node.Title) // Uses title from MarkdownFile
 	assert.Equal(t, []string{"tag1", "tag2"}, node.Tags)
 	assert.Equal(t, "Test content", node.Content)
 	assert.Equal(t, "test.md", node.FilePath)


### PR DESCRIPTION
## Summary
- Simplified `extractTitle()` to just remove .md extension without transformations
- Consolidated all title logic (including frontmatter override) into a single function
- Removed redundant title extraction from graph_builder.go

## Changes
1. **Updated `extractTitle()` function** in `markdown.go`:
   - Now accepts both path and frontmatter parameters
   - Checks frontmatter for title field first
   - Falls back to filename without .md extension (no transformations)

2. **Removed redundant logic** from `graph_builder.go`:
   - Title extraction from frontmatter is now handled in markdown.go
   - Graph builder simply uses the title from MarkdownFile

3. **Updated all tests** to match new behavior:
   - Test expectations now use raw filenames
   - Added new test for frontmatter title override functionality

## Impact
- Graph nodes will show raw filenames (without transformations) unless a frontmatter title is provided
- Existing frontmatter titles continue to work exactly as before
- The change is backward compatible for users who already use frontmatter titles

## Examples
- `simple.md` → `simple` (not `Simple`)
- `my-document.md` → `my-document` (not `My Document`)
- `~hub-node.md` → `~hub-node` (not `Hub Node`)
- File with frontmatter `title: "Custom Title"` → `Custom Title`

## Test plan
- [x] All vault tests pass
- [x] All backend tests pass
- [x] New tests added for frontmatter title override

Fixes #7

🤖 Generated with [Claude Code](https://claude.ai/code)